### PR TITLE
TransactionsPart

### DIFF
--- a/LoanShark/LoanShark.API/Controllers/TransactionsController.cs
+++ b/LoanShark/LoanShark.API/Controllers/TransactionsController.cs
@@ -1,0 +1,79 @@
+﻿using LoanShark.API.Models;
+using LoanShark.API.Proxies;
+using LoanShark.Domain;
+using LoanShark.Service.BankService;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LoanShark.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TransactionsController : ControllerBase
+    {
+        private readonly ITransactionsService transactionsService;
+
+        public TransactionsController(ITransactionsService transactionsService)
+        {
+            transactionsService = transactionsService;
+        }
+
+        [HttpPost("AddTransaction")]
+        public async Task<IActionResult> AddTransaction([FromBody] AddTransactionDTO dto)
+        {
+            if (!ModelState.IsValid) return BadRequest(ModelState);
+
+            try
+            {
+                var result = await transactionsService.AddTransaction(dto.SenderIban, dto.ReceiverIban, dto.Amount, dto.TransactionDescription);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Failed to add transaction: {ex.Message}");
+            }
+        }
+
+        [HttpPost("TakeLoanTransaction")]
+        public async Task<IActionResult> TakeLoanTransaction([FromBody] TakeLoanTransactionDTO dto)
+        {
+            try
+            {
+                var result = await transactionsService.TakeLoanTransaction(dto.Iban, dto.LoanAmount);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Failed to take loan: {ex.Message}");
+            }
+        }
+
+        [HttpPost("PayLoanTransaction")]
+        public async Task<IActionResult> PayLoanTransaction([FromBody] PayLoanTransactionDTO dto)
+        {
+            try
+            {
+                var result = await transactionsService.PayLoanTransaction(dto.Iban, dto.PaymentAmount);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Failed to pay loan: {ex.Message}");
+            }
+        }
+
+        [HttpGet("GetAllCurrencyExchangeRates")]
+        public async Task<ActionResult<List<CurrencyExchange>>> GetAllCurrencyExchangeRates()
+        {
+            try
+            {
+                var result = await transactionsService.GetAllCurrencyExchangeRates();
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Error retrieving exchange rates: {ex.Message}");
+            }
+        }
+    }
+
+}

--- a/LoanShark/LoanShark.API/Program.cs
+++ b/LoanShark/LoanShark.API/Program.cs
@@ -1,3 +1,5 @@
+using LoanShark.EF.Repository.BankRepository;
+using LoanShark.Service.BankService;
 using LoanShark.Web.Extensions;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,6 +22,10 @@ namespace LoanShark.Web
             builder.Services.AddScoped<ILoanSharkDbContext>(provider =>
                 provider.GetRequiredService<LoanSharkDbContext>());
             builder.Services.AddAllServiceProxies();
+
+            //Florin Transaction
+            builder.Services.AddScoped<ITransactionsService, TransactionsService>();
+            builder.Services.AddScoped<ITransactionsRepository, TransactionsRepositoryEF>();
 
             var app = builder.Build();
 

--- a/LoanShark/LoanShark.API/Proxies/TransactionsServiceProxy.cs
+++ b/LoanShark/LoanShark.API/Proxies/TransactionsServiceProxy.cs
@@ -1,0 +1,167 @@
+﻿using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Transactions;
+using LoanShark.API.Models;
+using LoanShark.Data;
+using LoanShark.Domain;
+using LoanShark.EF.Repository.BankRepository;
+using LoanShark.Service.BankService;
+
+//add namespace LoanShark.API.Proxies;
+
+namespace LoanShark.API.Proxies
+{
+    public class TransactionsServiceProxy : ITransactionsService
+    {
+        private readonly HttpClient _httpClient;
+
+        public TransactionsServiceProxy(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<string> AddTransaction(string senderIban, string receiverIban, decimal amount, string transactionDescription = "")
+        {
+            try
+            {
+                var dto = new AddTransactionDTO
+                {
+                    SenderIban = senderIban,
+                    ReceiverIban = receiverIban,
+                    Amount = amount,
+                    TransactionDescription = transactionDescription
+                };
+
+                var content = new StringContent(
+                    JsonSerializer.Serialize(dto),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+
+                var response = await _httpClient.PostAsync("https://localhost:7097/api/Transactions/AddTransaction", content);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<string>(json);
+                return result ?? "empty string";
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("EROARE ADD TRANSACTION PROXY", ex);
+            }
+        }
+
+        public async Task<string> TakeLoanTransaction(string iban, decimal loanAmount)
+        {
+            var dto = new TakeLoanTransactionDTO
+            {
+                Iban = iban,
+                LoanAmount = loanAmount
+            };
+
+            var json = JsonSerializer.Serialize(dto);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            try
+            {
+                using var response = await _httpClient.PostAsync("https://localhost:7097/api/Transactions/PayLoanTransaction", content);
+                response.EnsureSuccessStatusCode();
+
+                var responseBody = await response.Content.ReadAsStringAsync();
+
+                return !string.IsNullOrWhiteSpace(responseBody)
+                    ? responseBody
+                    : "empty string";
+            }
+            catch (HttpRequestException httpEx)
+            {
+                throw new Exception("HTTP request failed while taking loan transaction.", httpEx);
+            }
+            catch (JsonException jsonEx)
+            {
+                throw new Exception("Failed to parse the response JSON.", jsonEx);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("An unexpected error occurred while taking loan transaction.", ex);
+            }
+        }
+
+
+        public async Task<string> PayLoanTransaction(string iban, decimal paymentAmount)
+        {
+            var dto = new PayLoanTransactionDTO
+            {
+                Iban = iban,
+                PaymentAmount = paymentAmount
+            };
+
+            var json = JsonSerializer.Serialize(dto);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            try
+            {
+                using var response = await _httpClient.PostAsync("https://localhost:7097/api/Transactions/PayLoanTransaction", content);
+                response.EnsureSuccessStatusCode();
+
+                var responseBody = await response.Content.ReadAsStringAsync();
+
+                return !string.IsNullOrWhiteSpace(responseBody)
+                    ? responseBody
+                    : "empty string";
+            }
+            catch (HttpRequestException httpEx)
+            {
+                throw new Exception("HTTP request failed while paying loan transaction.", httpEx);
+            }
+            catch (JsonException jsonEx)
+            {
+                throw new Exception("Failed to parse the response JSON.", jsonEx);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("An unexpected error occurred while paying loan transaction.", ex);
+            }
+        }
+
+
+        public async Task<List<CurrencyExchange>> GetAllCurrencyExchangeRates()
+        {
+            try
+            {
+                var response = await _httpClient.GetAsync("https://localhost:7097/api/Transactions/GetAllCurrencyExchangeRates"); // Adjust port
+                response.EnsureSuccessStatusCode();
+                var json = await response.Content.ReadAsStringAsync();
+                var dto = JsonSerializer.Deserialize<List<CurrencyExchange>>(json);
+                return dto != null ? dto : new List<CurrencyExchange>();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving currency exchange rates: {ex.Message}", ex);
+            }
+        }
+    }
+    public class TakeLoanTransactionDTO
+    {
+        public string Iban { get; set; }
+        public decimal LoanAmount { get; set; }
+    }
+
+    public class AddTransactionDTO
+    {
+        public string SenderIban { get; set; }
+        public string ReceiverIban { get; set; }
+        public decimal Amount { get; set; }
+        public string TransactionDescription { get; set; }
+    }
+
+    public class PayLoanTransactionDTO
+    {
+        public string Iban { get; set; }
+        public decimal PaymentAmount { get; set; }
+    }
+
+}

--- a/LoanShark/LoanShark.EF/Repository/BankRepository/TransactionsRepositoryEF.cs
+++ b/LoanShark/LoanShark.EF/Repository/BankRepository/TransactionsRepositoryEF.cs
@@ -1,0 +1,226 @@
+﻿using LoanShark.Data;
+using LoanShark.Domain;
+using LoanShark.EF.EFModels;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LoanShark.EF.Repository.BankRepository
+{
+    public class TransactionsRepositoryEF : ITransactionsRepository
+    {
+        private readonly ILoanSharkDbContext _dbContext;
+
+        public TransactionsRepositoryEF(ILoanSharkDbContext dbContext)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        }
+
+        public async Task<bool> AddTransaction(Transaction transaction)
+        {
+            if (transaction == null)
+            {
+                throw new ArgumentNullException(nameof(transaction), "Transaction cannot be null");
+            }
+            try
+            {
+                var transactionEntity = new TransactionEF
+                {
+                    SenderIban = transaction.SenderIban,
+                    ReceiverIban = transaction.ReceiverIban,
+                    SenderCurrency = transaction.SenderCurrency,
+                    ReceiverCurrency = transaction.ReceiverCurrency,
+                    SenderAmount = transaction.SenderAmount,
+                    ReceiverAmount = transaction.ReceiverAmount,
+                    TransactionType = transaction.TransactionType,
+                    TransactionDescription = string.IsNullOrWhiteSpace(transaction.TransactionDescription) ? null : transaction.TransactionDescription,
+                    TransactionDatetime = DateTime.UtcNow
+                };
+
+                _dbContext.Transaction.Add(transactionEntity);
+                await _dbContext.SaveChangesAsync();
+
+                return true;
+            }
+            catch (SqlException ex)
+            {
+                throw new Exception($"Database error in AddTransaction: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<List<BankAccount>> GetAllBankAccounts()
+        {
+            try
+            {
+                List<BankAccount> bankAccounts = await _dbContext.BankAccount
+                    .Select(bankAccount => new BankAccount(
+                        bankAccount.Iban,
+                        bankAccount.Currency,
+                        bankAccount.Balance,
+                        bankAccount.Blocked,
+                        bankAccount.UserID,
+                        bankAccount.Name,
+                        bankAccount.DailyLimit,
+                        bankAccount.MaximumPerTransaction,
+                        bankAccount.MaximumNrTransactions
+                    ))
+                    .ToListAsync();
+                return bankAccounts;
+            }
+            catch (SqlException ex)
+            {
+                throw new Exception($"Database error in GetAllBankAccounts: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<List<CurrencyExchange>> GetAllCurrencyExchangeRates()
+        {
+            try
+            {
+                List<CurrencyExchange> exchangeRates = await _dbContext.CurrencyExchange
+                    .Select(exchangeRate => new CurrencyExchange(
+                        exchangeRate.FromCurrency,
+                        exchangeRate.ToCurrency,
+                        exchangeRate.ExchangeRate))
+                    .ToListAsync();
+                return exchangeRates;
+            }
+            catch (SqlException ex)
+            {
+                throw new Exception($"Database error in GetAllCurrencyExchangeRates: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<BankAccount?> GetBankAccountByIBAN(string iban)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(iban))
+                {
+                    throw new ArgumentException("IBAN cannot be empty.", nameof(iban));
+                }
+
+                var entity = await _dbContext.BankAccount
+                    .FirstOrDefaultAsync(acc => acc.Iban == iban);
+
+                if (entity == null)
+                    return null;
+
+                return new BankAccount(
+                        entity.Iban,
+                        entity.Currency,
+                        entity.Balance,
+                        entity.Blocked,
+                        entity.UserID,
+                        entity.Name,
+                        entity.DailyLimit,
+                        entity.MaximumPerTransaction,
+                        entity.MaximumNrTransactions
+                );
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"ORM error in GetBankAccountByIBAN: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<List<Transaction>> GetBankAccountTransactions(string iban)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(iban))
+                {
+                    throw new ArgumentException("IBAN cannot be empty.", nameof(iban));
+                }
+
+                var transactions = await _dbContext.Transaction
+                .Where(t => t.SenderIban == iban || t.ReceiverIban == iban)
+                .Select(t => new Transaction(
+                    t.TransactionId,
+                    t.SenderIban,
+                    t.ReceiverIban,
+                    t.TransactionDatetime,
+                    t.SenderCurrency,
+                    t.ReceiverCurrency,
+                    t.SenderAmount,
+                    t.ReceiverAmount,
+                    t.TransactionType,
+                    t.TransactionDescription ?? string.Empty
+                ))
+                .ToListAsync();
+
+                return transactions;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"ORM error in GetBankAccountTransactions: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<decimal> GetExchangeRate(string fromCurrency, string toCurrency)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(fromCurrency) || string.IsNullOrWhiteSpace(toCurrency))
+                {
+                    throw new ArgumentException("Currency codes cannot be null or empty.");
+                }
+
+                var exchangeRate = await _dbContext.CurrencyExchange
+                    .Where(c => c.FromCurrency == fromCurrency && c.ToCurrency == toCurrency)
+                    .Select(c => c.ExchangeRate)
+                    .FirstOrDefaultAsync();
+
+                if (exchangeRate == 0)
+                {
+                    throw new Exception("Exchange rate not found for the provided currencies.");
+                }
+
+                return exchangeRate;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving exchange rate: {ex.Message}", ex);
+            }
+        }
+
+        public async Task<bool> UpdateBankAccountBalance(string iban, decimal newBalance)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(iban))
+                {
+                    throw new ArgumentException("IBAN must be provided.", nameof(iban));
+                }
+
+                if (newBalance < 0)
+                {
+                    throw new ArgumentException("Balance cannot be negative.");
+                }
+
+                var bankAccount = await _dbContext.BankAccount
+                    .FirstOrDefaultAsync(b => b.Iban == iban);
+
+                if (bankAccount == null)
+                {
+                    throw new Exception($"Bank account with IBAN {iban} not found.");
+                }
+
+                bankAccount.Balance = newBalance;
+
+                await _dbContext.SaveChangesAsync();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error updating bank account balance: {ex.Message}", ex);
+            }
+        }
+    }
+}

--- a/LoanShark/LoanShark.Service/Service/BankService/TransactionsService.cs
+++ b/LoanShark/LoanShark.Service/Service/BankService/TransactionsService.cs
@@ -8,14 +8,14 @@ using LoanShark.EF.Repository.BankRepository;
 
 namespace LoanShark.Service.BankService
 {
-    public class TransactionsService
+    public class TransactionsService : ITransactionsService
     {
         private ITransactionsRepository transactionsRepository;
 
-        public TransactionsService()
-        {
-            transactionsRepository = new TransactionsRepository(DataLink.Instance);
-        }
+        //public TransactionsService()
+        //{
+        //    transactionsRepository = new TransactionsRepositoryEF(DataLink.Instance);
+        //}
 
         public TransactionsService(ITransactionsRepository transactionsRepository)
         {
@@ -234,5 +234,13 @@ namespace LoanShark.Service.BankService
                 throw new Exception($"Error retrieving currency exchange rates: {ex.Message}", ex);
             }
         }
+    }
+   
+    public interface ITransactionsService
+    {
+        public Task<string> AddTransaction(string senderIban, string receiverIban, decimal amount, string transactionDescription = "");
+        public Task<string> TakeLoanTransaction(string iban, decimal loanAmount);
+        public Task<string> PayLoanTransaction(string iban, decimal paymentAmount);
+        public Task<List<CurrencyExchange>> GetAllCurrencyExchangeRates();
     }
 }

--- a/LoanShark/LoanShark/LoanShark.csproj
+++ b/LoanShark/LoanShark/LoanShark.csproj
@@ -119,6 +119,7 @@
     <None Remove="TransactionHistory.xaml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\LoanShark.API\LoanShark.API.csproj" />
     <ProjectReference Include="..\LoanShark.Domain\LoanShark.Domain.csproj" />
     <ProjectReference Include="..\LoanShark.EF\LoanShark.EF.csproj" />
     <ProjectReference Include="..\LoanShark.Service\LoanShark.Service.csproj" />

--- a/LoanShark/LoanShark/ViewModel/BankViewModel/CurrencyExchangeTableViewModel.cs
+++ b/LoanShark/LoanShark/ViewModel/BankViewModel/CurrencyExchangeTableViewModel.cs
@@ -4,12 +4,13 @@ using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using LoanShark.Service.BankService;
 using LoanShark.Domain;
+using LoanShark.API.Proxies;
 
 namespace LoanShark.ViewModel.BankViewModel
 {
     public class CurrencyExchangeTableViewModel : ObservableObject
     {
-        private readonly TransactionsService transactionService;
+        private readonly ITransactionsService transactionService;
 
         public ObservableCollection<CurrencyExchange> ExchangeRates { get; } = new ObservableCollection<CurrencyExchange>();
 
@@ -19,7 +20,15 @@ namespace LoanShark.ViewModel.BankViewModel
 
         public CurrencyExchangeTableViewModel()
         {
-            transactionService = new TransactionsService();
+            transactionService = new TransactionsServiceProxy(new System.Net.Http.HttpClient());
+            LoadExchangeRatesAsync();
+
+            CloseCommand = new RelayCommand(CloseWindow);
+        }
+
+        public CurrencyExchangeTableViewModel(ITransactionsService transactionsService)
+        {
+            this.transactionService = transactionService;
             LoadExchangeRatesAsync();
 
             CloseCommand = new RelayCommand(CloseWindow);

--- a/LoanShark/LoanShark/ViewModel/BankViewModel/SendMoneyViewModel.cs
+++ b/LoanShark/LoanShark/ViewModel/BankViewModel/SendMoneyViewModel.cs
@@ -6,12 +6,13 @@ using System.Runtime.CompilerServices;
 using LoanShark.Domain;
 using LoanShark.Service.BankService;
 using Microsoft.UI.Xaml;
+using LoanShark.API.Proxies;
 
 namespace LoanShark.ViewModel.BankViewModel
 {
     public class SendMoneyViewModel : INotifyPropertyChanged
     {
-        private readonly TransactionsService transactionService;
+        private readonly ITransactionsService transactionService;
 
         private string iban;
         private string sumOfMoney;
@@ -93,7 +94,7 @@ namespace LoanShark.ViewModel.BankViewModel
 
         public SendMoneyViewModel()
         {
-            transactionService = new TransactionsService();
+            transactionService = new TransactionsServiceProxy(new System.Net.Http.HttpClient());
             // Initialize properties
             iban = string.Empty;
             sumOfMoney = string.Empty;


### PR DESCRIPTION
Am adaugat:
- ITransactionsService interface
- TransactionsServiceProxy ce implementeaza ITransactionsService si face request-uri pe HTTP
- TransactionsController: foloseste TransactionsService cel vechi pentru a raspunde la request-uri
- TransactionsRepositoryEF: identic cu TransactionsRepository vechi doar ca foloseste dbContext in loc de DataLink
- Am adaugat 2 dependency injections in Program.cs pentru TransactionsRepositoryEF si TransactionsService
- Cine folosea in trecut TransactionsService pe frontend acum foloseste TransactionsServiceProxy