### PR TITLE
small UserMapper fix

### DIFF
--- a/LoanShark/LoanShark.EF/Mappers/UserMapper.cs
+++ b/LoanShark/LoanShark.EF/Mappers/UserMapper.cs
@@ -30,8 +30,7 @@ namespace LoanShark.EF.Mappers
                     PhoneNumber = new PhoneNumber(userEF.PhoneNumber),
                     Username = userEF.Username,
                     ReportedCount = userEF.ReportedCount,
-                    //?
-                    HashedPassword = new HashedPassword(userEF.HashedPassword),
+                    HashedPassword = new HashedPassword(userEF.HashedPassword, userEF.PasswordSalt, false),
                     Friends = new List<int>(),
                     Chats = new List<int>(),
                 };


### PR DESCRIPTION
Un mic fix la usermapper ca sa nu dea hash la o parola deja hashed (care ii luata din db) si sa ii genereze un nou salt.

Din cate am inteles asa trebuie facut, din cauza ca in db is stored parolele hashed

Comentariile din cod de la functie:
// this constructor will be used to create a HashedPassword object with the data retrieved
// from the database which will allways be valid
// if this is the password data retrieved from the database, no need for hashing